### PR TITLE
Fix : arrayIntegers1 and arrayIntegers3 results are not correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ JSON.stringify(object)
 The **slice()** method returns the selected elements in an array as a new array object. It selects the elements starting at the given start argument, and ends at the given optional end argument without including the last element. If you omit the second argument then it selects till the end. Some of the examples of this method are,
 ```javascript
 let arrayIntegers = [1, 2, 3, 4, 5];
-let arrayIntegers1 = arrayIntegers.slice(2,2); // returns [1,2]
+let arrayIntegers1 = arrayIntegers.slice(0,2); // returns [1,2]
 let arrayIntegers2 = arrayIntegers.slice(2,3); // returns [3]
-let arrayIntegers3 = arrayIntegers.slice(4); //returns [4]
+let arrayIntegers3 = arrayIntegers.slice(4); //returns [5]
 ```
 **Note:** Slice method won't mutate the original array but it returns the subset as new array.
 


### PR DESCRIPTION
**Actula Result**
let arrayIntegers = [1, 2, 3, 4, 5];
let arrayIntegers1 = arrayIntegers.slice(2,2); // returns []
let arrayIntegers2 = arrayIntegers.slice(2,3); // returns [3]
let arrayIntegers3 = arrayIntegers.slice(4); //returns [5]

The first example changed because it returns an empty array