### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,13 +866,13 @@ function userDetails(username) {
     Let's take a simple example of variable hoisting,
     ```javascript
     console.log(message); //output : undefined
-    var message = ’The variable Has been hoisted’;
+    var message = 'The variable Has been hoisted';
     ```
     The above code looks like as below to the interpreter,
     ```javascript
     var message;
     console.log(message);
-    message = ’The variable Has been hoisted’;
+    message = 'The variable Has been hoisted';
     ```
 
     **[⬆ Back to Top](#table-of-contents)**


### PR DESCRIPTION
```’``` is used instead of ```'```, which produces an error if someone tries to copy it as they are actually a completely different character