### PR TITLE
Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1366,7 +1366,7 @@ function userDetails(username) {
     **[⬆ Back to Top](#table-of-contents)**
 
 66. ### What is a strict mode in javascript?
-    Strict Mode is a new feature in ECMAScript 5 that allows you to place a program, or a function, in a “strict” operating context. This way it prevents certain actions from being taken and throws more exceptions. The literal expression `“use strict”;` instructs the browser to use the javascript code in the Strict mode.
+    Strict Mode is a new feature in ECMAScript 5 that allows you to place a program, or a function, in a “strict” operating context. This way it prevents certain actions from being taken and throws more exceptions. The literal expression `"use strict";` instructs the browser to use the javascript code in the Strict mode.
 
     **[⬆ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
The character ```”``` is not the same as ```"``` And also produces an error when executed...