### PR TITLE
Fix for Question 120 (regex part)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2231,7 +2231,7 @@ Good luck with your interview 😊
      1. **Using RegEx:** The advanced solution is using Regular expression's test method(`RegExp.test`), which allows for testing for against regular expressions
 
      ```javascript
-     var mainString = "hello", regex = "/hell/";
+     var mainString = "hello", regex = /hell/;
      regex.test(mainString)
      ```
 


### PR DESCRIPTION
In Question 120 regex section, there is slight typo i.e regex must be without double quotes else it would send TypeError as ```regex.test is not a function```. So correct regex would be ```regex = /hell/``` which I have fixed in this PR.