### PR TITLE
Fix for Question 22 hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Good luck with your interview 😊
 |19 | [What is the reason to choose the name let as a keyword](#what-is-the-reason-to-choose-the-name-let-as-a-keyword)|
 |20 | [How do you redeclare variables in switch block without an error](#how-do-you-redeclare-variables-in-switch-block-without-an-error)|
 |21 | [What is the Temporal Dead Zone](#what-is-the-temporal-dead-zone)|
-|22 | [What is IIFE(Immediately Invoked Function Expression)](#what-is-iife%28immediately-invoked-function-expression%29)|
+|22 | [What is IIFE(Immediately Invoked Function Expression)](#what-is-iifeimmediately-invoked-function-expression)|
 |23 | [What is the benefit of using modules](#what-is-the-benefit-of-using-modules)|
 |24 | [What is memoization](#what-is-memoization)|
 |25 | [What is Hoisting](#what-is-hoisting)|

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Good luck with your interview 😊
 |19 | [What is the reason to choose the name let as a keyword](#what-is-the-reason-to-choose-the-name-let-as-a-keyword)|
 |20 | [How do you redeclare variables in switch block without an error](#how-do-you-redeclare-variables-in-switch-block-without-an-error)|
 |21 | [What is the Temporal Dead Zone](#what-is-the-temporal-dead-zone)|
-|22 | [What is IIFE(Immediately Invoked Function Expression)](#what-is-iife(immediately-invoked-function-expression)|
+|22 | [What is IIFE(Immediately Invoked Function Expression)](#what-is-iife%28immediately-invoked-function-expression%29)|
 |23 | [What is the benefit of using modules](#what-is-the-benefit-of-using-modules)|
 |24 | [What is memoization](#what-is-memoization)|
 |25 | [What is Hoisting](#what-is-hoisting)|


### PR DESCRIPTION
The first approach was to encode the parenthesis in hyperlink string that worked in VScode markdown preview but unfortunately, it didn't work in Github preview.
The second approach was not to consider parenthesis in hyperlink string and that works.