### PR TITLE
Fix mistake with exercise

### DIFF
--- a/coding-exercise/superArrayOfObjects/README.md
+++ b/coding-exercise/superArrayOfObjects/README.md
@@ -3,7 +3,7 @@
 #### Example
 ```js
 [
-    { language: 'JavaScript' },{ language: 'JavaScript' },{ language: 'TypeScript' },
+    { language: 'JavaScript' }, { language: 'JavaScript' }, { language: 'TypeScript' }, { language: 'C++' }
 ] 
 ```
 


### PR DESCRIPTION
It showed C++ in the converted array, but it was never in the first array