### PR TITLE
Q51: Better `Promise` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1431,16 +1431,18 @@
     The usage of a promise would be as below,
 
     ```javascript
-    const promise = new Promise(
-      (resolve) => {
-        setTimeout(() => {
-          resolve("I'm a Promise!");
-        }, 5000);
-      },
-      (reject) => {}
-    );
-
-    promise.then((value) => console.log(value));
+    const promise = new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (Math.random() > 0.5) { // 50% chance of true
+          resolve("I'm a successful Promise!");
+        } else {
+          reject("I'm a failed Promise");
+        }
+      }, 1000);
+    });
+      
+    promise.then((value) => console.log(value))
+      .catch((error) => console.error(error));
     ```
 
     The action flow of a promise will be as below,


### PR DESCRIPTION
Previously, the example given included two parameters passed to the `Promise` constructor.  This is not correct, `Promise()` should take take one `executor` parameter ([source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise#parameters)).

This PR provides a new example, which uses the proper syntax, and also shows uses of both the `resolve` and `reject` callbacks. 