### PR TITLE
Update README.md to correct the way we are checking browser for compatibility with web worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1436,7 +1436,10 @@
     1. Create a Web Worker Object: You can create a web worker object by checking for browser support. Let's name this file as web_worker_example.js
 
     ```javascript
-    if (typeof w == "undefined") {
+
+    let w;
+    
+    if (typeof Worker !== "undefined") {
       w = new Worker("counter.js");
     }
     ```


### PR DESCRIPTION
In question 49, w is being declared without a proper keyword, which this PR will fix by declaring the same with 'let' keyword.

We also are checking if w is undefined, which is not necessary since it will be reinitialized. The missing component here is a check for browser compatibility with web workers, which is added now.